### PR TITLE
Update QUEERTY keyboard features

### DIFF
--- a/QueertyKeyboard/README.md
+++ b/QueertyKeyboard/README.md
@@ -1,6 +1,6 @@
 # Queerty Keyboard
 
-This is a sample Android keyboard designed for the LGBT+ community. The layout swaps `Z`/`Y` and `W`/`U` to form **QUERTY**. The Caps Lock key is replaced by **Caps Love** which shows a heart toast. When typing words like `Love`, `Gay`, `Pride` or `Radosť` a short celebration toast appears.
+This is a sample Android keyboard designed for the LGBT+ community. The first row spells **QUEERTY** and the `P` key is moved down to keep the row balanced. Caps Lock was removed and replaced by a rainbow button that inserts the rainbow emoji. Extra emoji keys (heart, unicorn and pride flag) are included. Typing words like `Love`, `Gay`, `LGBTI`, `Pride`, `Hrdosť` or `Radosť` shows a short confetti toast.
 
 ## Building
 

--- a/QueertyKeyboard/app/src/main/java/com/queerty/keyboard/QueertyKeyboardService.kt
+++ b/QueertyKeyboard/app/src/main/java/com/queerty/keyboard/QueertyKeyboardService.kt
@@ -11,8 +11,12 @@ class QueertyKeyboardService : InputMethodService(), KeyboardView.OnKeyboardActi
 
     private lateinit var kv: KeyboardView
     private lateinit var keyboard: Keyboard
-    private var caps = false
-    private var typed = StringBuilder()
+    private val typed = StringBuilder()
+
+    private val RAINBOW_CODE = -101
+    private val HEART_CODE = -102
+    private val UNICORN_CODE = -103
+    private val FLAG_CODE = -104
 
     override fun onCreateInputView(): View {
         kv = layoutInflater.inflate(R.layout.keyboard_view, null) as KeyboardView
@@ -26,12 +30,14 @@ class QueertyKeyboardService : InputMethodService(), KeyboardView.OnKeyboardActi
         val ic: InputConnection = currentInputConnection
         when (primaryCode) {
             Keyboard.KEYCODE_DELETE -> ic.deleteSurroundingText(1, 0)
-            Keyboard.KEYCODE_SHIFT -> handleCapsLove()
             Keyboard.KEYCODE_DONE -> ic.sendKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_ENTER))
+            RAINBOW_CODE -> ic.commitText("\uD83C\uDF08", 1)
+            HEART_CODE -> ic.commitText("\u2764\uFE0F", 1)
+            UNICORN_CODE -> ic.commitText("\uD83E\uDD84", 1)
+            FLAG_CODE -> ic.commitText("\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08", 1)
             else -> {
                 val code = primaryCode.toChar()
-                val text = if (caps) code.uppercaseChar().toString() else code.toString()
-                ic.commitText(text, 1)
+                ic.commitText(code.toString(), 1)
                 typed.append(code)
                 checkForConfetti()
             }
@@ -52,14 +58,10 @@ class QueertyKeyboardService : InputMethodService(), KeyboardView.OnKeyboardActi
 
     override fun swipeUp() {}
 
-    private fun handleCapsLove() {
-        caps = !caps
-        Toast.makeText(this, "\uD83D\uDC95", Toast.LENGTH_SHORT).show()
-    }
-
     private fun checkForConfetti() {
         val word = typed.toString().lowercase()
-        if (word.endsWith("love") || word.endsWith("gay") || word.endsWith("pride") || word.endsWith("radosť")) {
+        val keywords = listOf("love", "gay", "pride", "lgbti", "hrdosť", "hrdost", "radosť", "radost")
+        if (keywords.any { word.endsWith(it) }) {
             Toast.makeText(this, "\uD83C\uDF89", Toast.LENGTH_SHORT).show()
             typed.clear()
         }

--- a/QueertyKeyboard/app/src/main/res/drawable/key_bg.xml
+++ b/QueertyKeyboard/app/src/main/res/drawable/key_bg.xml
@@ -1,8 +1,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <gradient
         android:startColor="#FF0000"
-        android:centerColor="#FFFF00"
-        android:endColor="#0000FF"
+        android:centerColor="#00FF00"
+        android:endColor="#8B00FF"
         android:angle="45"/>
     <corners android:radius="4dp"/>
 </shape>

--- a/QueertyKeyboard/app/src/main/res/xml/keyboard_layout.xml
+++ b/QueertyKeyboard/app/src/main/res/xml/keyboard_layout.xml
@@ -8,9 +8,13 @@
         <Key android:codes="113" android:keyLabel="Q" />
         <Key android:codes="117" android:keyLabel="U" />
         <Key android:codes="101" android:keyLabel="E" />
+        <Key android:codes="101" android:keyLabel="E" />
         <Key android:codes="114" android:keyLabel="R" />
         <Key android:codes="116" android:keyLabel="T" />
         <Key android:codes="121" android:keyLabel="Y" />
+        <Key android:codes="119" android:keyLabel="W" />
+        <Key android:codes="105" android:keyLabel="I" />
+        <Key android:codes="111" android:keyLabel="O" />
     </Row>
     <Row>
         <Key android:codes="97" android:keyLabel="A" />
@@ -19,11 +23,9 @@
         <Key android:codes="102" android:keyLabel="F" />
         <Key android:codes="103" android:keyLabel="G" />
         <Key android:codes="104" android:keyLabel="H" />
-    </Row>
-    <Row>
-        <Key android:codes="119" android:keyLabel="W" />
-        <Key android:codes="105" android:keyLabel="I" />
-        <Key android:codes="111" android:keyLabel="O" />
+        <Key android:codes="106" android:keyLabel="J" />
+        <Key android:codes="107" android:keyLabel="K" />
+        <Key android:codes="108" android:keyLabel="L" />
         <Key android:codes="112" android:keyLabel="P" />
     </Row>
     <Row>
@@ -36,9 +38,12 @@
         <Key android:codes="109" android:keyLabel="M" />
     </Row>
     <Row>
-        <Key android:codes="-1" android:keyLabel="Caps Love" android:isModifier="true" android:keyWidth="20%p" />
-        <Key android:codes="32" android:keyLabel="Space" android:keyWidth="40%p" />
-        <Key android:codes="10" android:keyLabel="Enter" android:keyWidth="20%p" />
-        <Key android:codes="-5" android:keyLabel="Del" android:keyWidth="20%p" />
+        <Key android:codes="-101" android:keyLabel="\uD83C\uDF08" android:keyWidth="14%p" />
+        <Key android:codes="-102" android:keyLabel="\u2764\uFE0F" android:keyWidth="14%p" />
+        <Key android:codes="-103" android:keyLabel="\uD83E\uDD84" android:keyWidth="14%p" />
+        <Key android:codes="-104" android:keyLabel="\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08" android:keyWidth="14%p" />
+        <Key android:codes="32" android:keyLabel="Space" android:keyWidth="30%p" />
+        <Key android:codes="10" android:keyLabel="Enter" android:keyWidth="12%p" />
+        <Key android:codes="-5" android:keyLabel="Del" android:keyWidth="12%p" />
     </Row>
 </Keyboard>


### PR DESCRIPTION
## Summary
- enhance README to describe rainbow emoji key and confetti
- add emoji constants and handle emoji codes in `QueertyKeyboardService`
- update checkForConfetti with new keywords
- redesign layout with QUEERTY first row, move `P` to second row
- add rainbow gradient and emoji keys

## Testing
- `./gradlew --version` *(fails: command not found or missing wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68429d59519c83259c3fa7e4a82c8ca4