### PR TITLE
Add rainbow heart emoji shortcut

### DIFF
--- a/QueertyKeyboard/README.md
+++ b/QueertyKeyboard/README.md
@@ -1,6 +1,6 @@
 # Queerty Keyboard
 
-This is a sample Android keyboard designed for the LGBT+ community. The first row spells **QUEERTY** and the `P` key is moved down to keep the row balanced. Caps Lock was removed and replaced by a rainbow button that inserts the rainbow emoji. Extra emoji keys (heart, unicorn and pride flag) are included. Typing words like `Love`, `Gay`, `LGBTI`, `Pride`, `Hrdosť` or `Radosť` shows a short confetti toast.
+This is a sample Android keyboard designed for the LGBT+ community. The first row spells **QUEERTY** and the `P` key is moved down to keep the row balanced. Caps Lock was removed and replaced by a rainbow button that inserts the rainbow emoji. Extra emoji keys (heart, rainbow heart, unicorn and pride flag) are included. Typing words like `Love`, `Gay`, `LGBTI`, `Pride`, `Hrdosť` or `Radosť` shows a short confetti toast.
 
 ## Building
 

--- a/QueertyKeyboard/app/src/main/java/com/queerty/keyboard/QueertyKeyboardService.kt
+++ b/QueertyKeyboard/app/src/main/java/com/queerty/keyboard/QueertyKeyboardService.kt
@@ -17,6 +17,7 @@ class QueertyKeyboardService : InputMethodService(), KeyboardView.OnKeyboardActi
     private val HEART_CODE = -102
     private val UNICORN_CODE = -103
     private val FLAG_CODE = -104
+    private val HEART_RAINBOW_CODE = -105
 
     override fun onCreateInputView(): View {
         kv = layoutInflater.inflate(R.layout.keyboard_view, null) as KeyboardView
@@ -35,6 +36,7 @@ class QueertyKeyboardService : InputMethodService(), KeyboardView.OnKeyboardActi
             HEART_CODE -> ic.commitText("\u2764\uFE0F", 1)
             UNICORN_CODE -> ic.commitText("\uD83E\uDD84", 1)
             FLAG_CODE -> ic.commitText("\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08", 1)
+            HEART_RAINBOW_CODE -> ic.commitText("\u2764\uFE0F\u200D\uD83C\uDF08", 1)
             else -> {
                 val code = primaryCode.toChar()
                 ic.commitText(code.toString(), 1)

--- a/QueertyKeyboard/app/src/main/res/xml/keyboard_layout.xml
+++ b/QueertyKeyboard/app/src/main/res/xml/keyboard_layout.xml
@@ -42,6 +42,7 @@
         <Key android:codes="-102" android:keyLabel="\u2764\uFE0F" android:keyWidth="14%p" />
         <Key android:codes="-103" android:keyLabel="\uD83E\uDD84" android:keyWidth="14%p" />
         <Key android:codes="-104" android:keyLabel="\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08" android:keyWidth="14%p" />
+        <Key android:codes="-105" android:keyLabel="\u2764\uFE0F\u200D\uD83C\uDF08" android:keyWidth="14%p" />
         <Key android:codes="32" android:keyLabel="Space" android:keyWidth="30%p" />
         <Key android:codes="10" android:keyLabel="Enter" android:keyWidth="12%p" />
         <Key android:codes="-5" android:keyLabel="Del" android:keyWidth="12%p" />


### PR DESCRIPTION
## Summary
- add a new rainbow heart emoji key
- handle the new key code in `QueertyKeyboardService`
- document the rainbow heart emoji shortcut

## Testing
- `./gradlew assembleDebug` *(fails: fork resource unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684ad2c1fd3083259953b85dc62f6bd5